### PR TITLE
Old file URL deprecated

### DIFF
--- a/put.io adder/PutioMainController.m
+++ b/put.io adder/PutioMainController.m
@@ -242,7 +242,7 @@
 
 - (void)userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:(NSUserNotification *)notification
 {
-    NSString *url = [NSString stringWithFormat:@"https://put.io/file/%@", [notification.userInfo valueForKey:@"fileID"]];
+    NSString *url = [NSString stringWithFormat:@"https://put.io/files/%@", [notification.userInfo valueForKey:@"fileID"]];
     [[NSWorkspace sharedWorkspace] openURL: [NSURL URLWithString: url]];
 }
 
@@ -258,7 +258,7 @@
     NSString *url;
     
     if (![[trans fileID] isEqualTo:[NSNull alloc]] && fileID != nil) {
-        url = [NSString stringWithFormat:@"https://put.io/file/%@", fileID];
+        url = [NSString stringWithFormat:@"https://put.io/files/%@", fileID];
     } else {
         url = @"https://put.io/transfers";
     }


### PR DESCRIPTION
I know, this patch is quite extensive. 😆  

The old URL still works, but when it's hit it gently 'nudges' you towards the new UI and mentions that this URL/style will be gone by October. Which is last month. So…quick patch.