### PR TITLE
Fix regex to parse callback URL & save access token

### DIFF
--- a/put.io adder/PutioHelper.m
+++ b/put.io adder/PutioHelper.m
@@ -340,7 +340,7 @@ static PutioHelper *sharedHelper = nil;
 - (void)saveAccessToken:(NSString *)url
 {
     NSError *error = nil;
-    NSString *pattern = @"^putio://callback#access_token=(.*)";
+    NSString *pattern = @"^putio://callback\\?#access_token=(.*)";
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];
     NSArray *matches = [regex matchesInString:url options:0 range:NSMakeRange(0, [url length])];
     


### PR DESCRIPTION
The callback URL was no longer being correctly parsed by the regex, possibly due to the fact that the callback URL from put.io might have changed at some point. Due to this, the access token is never saved and the put.io adder is stuck in a limbo waiting for authentication.

Fixes https://github.com/nicoSWD/put.io-adder/issues/24